### PR TITLE
Add custom Git command

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ export default defineNuxtConfig({
 - `version` - application version (`version in package.json` by default)
 - `ifGitSHA` - use git commit SHA as the version (`false` by default)
 - `ifShortSHA` - use git commit short SHA (`true` by default)
+- `gitCommand` - provide a custom Git command to retrieve the version (`git rev-parse --short HEAD` by default)
 - `ifMeta` - add \<meta name="application-name" content="{APPNAME_VERSION}: {version}"> in the \<head> (`true` by default)
 - `ifLog` - print info in the Console (`true` by default)
 - `ifGlobal` - set a variable named *\`\_\_${APPNAME}\_VERSION\_\_\`* in the window. (`true` by default)

--- a/src/plugins/core/main.ts
+++ b/src/plugins/core/main.ts
@@ -5,14 +5,22 @@ export interface VitePluginVersionMarkInput {
   version?: string
   ifGitSHA?: boolean
   ifShortSHA?: boolean
+  gitCommand?: string
   ifMeta?: boolean
   ifLog?: boolean
   ifGlobal?: boolean
 }
 
-const getGitSHA = (ifShortSHA: boolean) => {
+const getGitSHA = (ifShortSHA: boolean, gitCommand: string) => {
   const {exec} = childProcess
-  const sh = ifShortSHA ? 'git rev-parse --short HEAD' : 'git rev-parse HEAD'
+  let sh: string
+  if (gitCommand) {
+    sh = gitCommand
+  } else if (ifShortSHA) {
+    sh = 'git rev-parse --short HEAD'
+  } else {
+    sh = 'git rev-parse HEAD'
+  }
 
   return new Promise((resolve, reject) => {
     exec(sh, (error, stdout) => {
@@ -32,12 +40,13 @@ export const analyticOptions = async (options: VitePluginVersionMarkInput) => {
     version = process.env['npm_package_version'],
     ifGitSHA = false,
     ifShortSHA = true,
+    gitCommand = 'git rev-parse --short HEAD',
     ifMeta = true,
     ifLog = true,
     ifGlobal = true,
   } = options
 
-  const printVersion = ifGitSHA ? await getGitSHA(ifShortSHA) : version
+  const printVersion = ifGitSHA ? await getGitSHA(ifShortSHA, gitCommand) : version
   const printName = `${name?.replace(/((?!\w).)/g, '_')?.toLocaleUpperCase?.()}_VERSION`
   const printInfo = `${printName}: ${printVersion}`
 

--- a/src/plugins/core/main.ts
+++ b/src/plugins/core/main.ts
@@ -11,7 +11,7 @@ export interface VitePluginVersionMarkInput {
   ifGlobal?: boolean
 }
 
-const getGitSHA = (ifShortSHA: boolean, gitCommand: string) => {
+const getGitSHA = (ifShortSHA: boolean, gitCommand: string | undefined) => {
   const {exec} = childProcess
   let sh: string
   if (gitCommand) {
@@ -40,7 +40,7 @@ export const analyticOptions = async (options: VitePluginVersionMarkInput) => {
     version = process.env['npm_package_version'],
     ifGitSHA = false,
     ifShortSHA = true,
-    gitCommand = 'git rev-parse --short HEAD',
+    gitCommand = undefined,
     ifMeta = true,
     ifLog = true,
     ifGlobal = true,


### PR DESCRIPTION
This is a great project and meets my needs almost perfectly. My only request is to make it possible for users to specify their own Git command to retrieve the version string (I start with `git describe --tags` and then modify it to conform to our project's version standard). 

This PR adds the `gitCommand` config option, which, when set along with `ifGitSHA: true`, overrides either of the existing hard-coded Git commands. 

Thanks!