### PR TITLE
Store script tags for global variable in head instead of body

### DIFF
--- a/src/plugins/vite.ts
+++ b/src/plugins/vite.ts
@@ -82,7 +82,7 @@ export const vitePluginVersionMark: (options?: VitePluginVersionMarkInput) => Pl
       if (ifGlobal) {
         els.push({
           tag: 'script',
-          injectTo: 'body',
+          injectTo: 'head',
           children: `__${printName}__ = "${printVersion}"`,
         })
       }


### PR DESCRIPTION
Now the script tag containing the global variable is visible on the page due to being appended in the body element. This is not aesthetically pleasing. I moved the tag to the head to remove the element as an HTML element.