### PR TITLE
docs: update command description in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Then you can use `vite-plugin-version-mark` ! 🎉
 | version | application version | `string` | `version` in package.json | `0.0.1+` |
 | ifGitSHA | use git commit SHA as the version | `boolean` | false | `0.0.1+` |
 | ifShortSHA | use git commit short SHA as the version | `boolean` | false | `0.0.1+` |
-| command | provide a custom command to retrieve the version <br/>For example: `git describe --tags` | `string` | git rev-parse --short HEAD | `0.0.8+` |
+| command | provide a custom command to retrieve the version <br/>For example: `git describe --tags`. If you don't set command, when `ifShortSHA` is true, the default value is `git rev-parse --short HEAD`, when `ifGitSHA` is true, the default value is `git rev-parse HEAD`.  | `string` | undefined | `0.0.8+` |
 | ifLog | print info in the Console | `boolean` | true | `0.0.1+` |
 | ifGlobal | set a variable named *\`\_\_${APPNAME}\_VERSION\_\_\`* in the window<br/>[For TypeScript users, make sure to add the type declarations in the env.d.ts or vite-env.d.ts file to get type checks and Intellisense.](https://vitejs.dev/config/shared-options.html#define) | `boolean` | true | `0.0.4+` |
 | ifMeta | add \<meta name="application-name" content="{APPNAME_VERSION}: {version}"> in the \<head> | `boolean` | true | `0.0.1+` |

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -96,7 +96,7 @@ export default defineNuxtConfig({
 | version | 应用版本 | `string` | 在 `package.json` 中定义的 `version` 属性 | `0.0.1+` |
 | ifGitSHA | 使用git commitSHA作为版本号 | `boolean` | false | `0.0.1+` |
 | ifShortSHA | 使用git的短commitSHA作为版本号 | `boolean` | false | `0.0.1+` |
-| command | 提供自定义指令，以便自定义版本号的获取方式 <br/>例如使用git tag作为版本号: `git describe --tags` | `string` | git rev-parse --short HEAD | `0.0.8+` |
+| command | 提供自定义指令，以便自定义版本号的获取方式 <br/>例如使用git tag作为版本号: `git describe --tags`。如果没有设置command， `ifShortSHA` 为 true，默认值是 `git rev-parse --short HEAD`； `ifGitSHA` 为 true， 默认值是 `git rev-parse HEAD`。 | `string` | undefined | `0.0.8+` |
 | ifLog | 在控制台打印版本信息 | `boolean` | true | `0.0.1+` |
 | ifGlobal | 在window上定义变量 *\`\_\_${APPNAME}\_VERSION\_\_\`* <br/>[对于TypeScript使用者, 请确保您在 env.d.ts 或者 vite-env.d.ts 文件中定义该变量，以便通过类型检查。](https://vitejs.dev/config/shared-options.html#define) | `boolean` | true | `0.0.4+` |
 | ifMeta | 在 `<head>` 中添加 `<meta name="application-name" content="{APPNAME_VERSION}: {version}">` | `boolean` | true | `0.0.1+` |


### PR DESCRIPTION
I think we should update the default value of `command` option in readme by this code

![image](https://github.com/user-attachments/assets/66cfd099-9602-4df8-b1c2-766a8aba67a0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the `README.md` to clarify the `command` option for the `vite-plugin-version-mark` configuration, including its default behavior.
	- Revised the `README_ZH.md` for consistency with the English documentation, enhancing clarity on the `command` property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->